### PR TITLE
Passing profile as unquoted string

### DIFF
--- a/captcha-validation-service/Dockerfile
+++ b/captcha-validation-service/Dockerfile
@@ -71,4 +71,4 @@ USER ${container_user_uid}:${container_user_gid}
 
 EXPOSE 9089
 
-CMD java -jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" captcha-validation-service.jar
+CMD java -jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active=${active_profile_env} -Dspring.cloud.config.uri="${spring_config_url_env}" captcha-validation-service.jar


### PR DESCRIPTION
Below incorrect profile is interpreted -> 
{"@timestamp":"2024-10-11T16:26:04.720Z","@version":"1","message":"The following 1 profile is active: \"local\"","logger_name":"io.mosip.captcha.CaptchaServiceApplication","thread_name":"main","level":"INFO","level_value":20000,"appName":"captcha-validation-service"}

Hence removing the quotes in the dockerfile